### PR TITLE
Add Rovodev ACLI Vim plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ## 🛠 Features
 - Vim plugin for Forge CLI
+- **New:** Vim plugin for Rovodev ACLI
 - Tmux script to launch a dev session with tunnel/build/Vim panes
 - Example .vimrc
 
@@ -10,9 +11,16 @@
 
 1. Extract ZIP
 2. Move `plugin/vim-forge.vim` to `~/.vim/pack/plugins/start/vim-forge/plugin/`
-3. Update `scripts/forge-dev.sh` with your Forge app path
-4. Run the script: `./scripts/forge-dev.sh`
-5. Start coding!
+3. *(Optional)* Move `plugin/vim-rovodev.vim` to `~/.vim/pack/plugins/start/vim-rovodev/plugin/`
+4. Update `scripts/forge-dev.sh` with your Forge app path
+5. Run the script: `./scripts/forge-dev.sh`
+6. Start coding!
+
+### Rovodev ACLI Plugin
+
+After installing `vim-rovodev.vim`, use commands like `:RovoDeploy` and `:RovoTunnel`
+which simply call `acli rovodev deploy` and `acli rovodev tunnel`.  Mappings under
+`<leader>r` mirror the Forge mappings.
 
 ---
 Built by A9 GoBot 2.6 

--- a/doc/vim-rovodev.txt
+++ b/doc/vim-rovodev.txt
@@ -1,0 +1,27 @@
+*vim-rovodev.txt*  Plugin for Rovodev ACLI commands in Vim
+
+vim-rovodev.vim - Rovodev ACLI Vim Plugin
+=========================================
+
+This plugin provides Vim commands that wrap the Rovodev ACLI tool.
+
+Commands:
+  :RovoDeploy      - Run `acli rovodev deploy`
+  :RovoTunnel      - Run `acli rovodev tunnel`
+  :RovoInstall     - Run `acli rovodev install`
+  :RovoLogs        - Run `acli rovodev logs`
+
+Key Mappings (if enabled):
+  <leader>rd - Deploy
+  <leader>rt - Tunnel
+  <leader>ri - Install
+  <leader>rl - Logs
+
+Installation:
+  Drop this plugin into `~/.vim/pack/plugins/start/vim-rovodev/`
+  Or use a plugin manager like vim-plug or packer.nvim
+
+Help:
+  :help vim-rovodev
+
+vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/vim-rovodev.vim
+++ b/plugin/vim-rovodev.vim
@@ -1,0 +1,16 @@
+" vim-rovodev.vim - Rovodev ACLI plugin for Vim
+
+if exists('g:loaded_rovodev_plugin')
+  finish
+endif
+let g:loaded_rovodev_plugin = 1
+
+command! RovoDeploy :!acli rovodev deploy
+command! RovoTunnel :!acli rovodev tunnel
+command! RovoInstall :!acli rovodev install
+command! RovoLogs :!acli rovodev logs
+
+nnoremap <leader>rd :RovoDeploy<CR>
+nnoremap <leader>rt :RovoTunnel<CR>
+nnoremap <leader>ri :RovoInstall<CR>
+nnoremap <leader>rl :RovoLogs<CR>


### PR DESCRIPTION
## Summary
- add Vim commands for Rovodev ACLI
- document new Rovodev commands in `doc/vim-rovodev.txt`
- update README with install/use instructions for Rovodev plugin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d7283bbbc8327b03fe32f3392983d