### PR TITLE
Add rovodev tmux script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## 🛠 Features
 - Vim plugin for Forge CLI
 - **New:** Vim plugin for Rovodev ACLI
-- Tmux script to launch a dev session with tunnel/build/Vim panes
+- Tmux scripts to launch dev sessions for Forge or Rovodev
 - Example .vimrc
 
 ## 📦 How to Use
@@ -12,8 +12,9 @@
 1. Extract ZIP
 2. Move `plugin/vim-forge.vim` to `~/.vim/pack/plugins/start/vim-forge/plugin/`
 3. *(Optional)* Move `plugin/vim-rovodev.vim` to `~/.vim/pack/plugins/start/vim-rovodev/plugin/`
-4. Update `scripts/forge-dev.sh` with your Forge app path
-5. Run the script: `./scripts/forge-dev.sh`
+4. Update `scripts/forge-dev.sh` or `scripts/rovodev-dev.sh` with your app paths
+   (`APP_DIR` and optional `STATIC_DIR` variables)
+5. Run the script you need: `./scripts/forge-dev.sh` or `./scripts/rovodev-dev.sh`
 6. Start coding!
 
 ### Rovodev ACLI Plugin
@@ -21,6 +22,7 @@
 After installing `vim-rovodev.vim`, use commands like `:RovoDeploy` and `:RovoTunnel`
 which simply call `acli rovodev deploy` and `acli rovodev tunnel`.  Mappings under
 `<leader>r` mirror the Forge mappings.
+You can also start a full tmux workflow using `scripts/rovodev-dev.sh`.
 
 ---
 Built by A9 GoBot 2.6 

--- a/scripts/rovodev-dev.sh
+++ b/scripts/rovodev-dev.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SESSION="rovodev-dev"
+APP_DIR="$HOME/projects/your-rovodev-app"  # <-- UPDATE this path
+STATIC_DIR="$APP_DIR/static/hello-world"   # <-- UPDATE if needed
+
+tmux new-session -d -s $SESSION -c $APP_DIR
+
+tmux send-keys -t $SESSION 'vim' C-m
+
+tmux split-window -h -t $SESSION:0 -c $APP_DIR
+tmux send-keys -t $SESSION 'acli rovodev tunnel' C-m
+
+tmux split-window -v -t $SESSION:0.0 -c "$STATIC_DIR"
+tmux send-keys -t $SESSION 'npm run build' C-m
+
+tmux select-pane -t $SESSION:0.0
+
+tmux attach-session -t $SESSION


### PR DESCRIPTION
## Summary
- provide `scripts/rovodev-dev.sh` to mirror Forge workflow with acli
- make the script executable
- document usage and path variables

## Testing
- `bash -n scripts/rovodev-dev.sh`
- `bash -n scripts/forge-dev.sh`


------
https://chatgpt.com/codex/tasks/task_e_686d743ff7488327b35463beef3834e7