### PR TITLE
Add CLI checks to Vim plugins

### DIFF
--- a/plugin/vim-forge.vim
+++ b/plugin/vim-forge.vim
@@ -5,30 +5,35 @@ if exists('g:loaded_forge_plugin')
 endif
 let g:loaded_forge_plugin = 1
 
-command! ForgeCreate :!forge create
-command! ForgeDeploy :!forge deploy
-command! ForgeInstall :!forge install
-command! ForgeTunnel :!forge tunnel
-command! ForgeBuildStatic :!cd static/hello-world && npm install && npm run build
-command! ForgeBuildReact :!cd src/frontend && npm install && npm run build
-command! ForgeLogs :!forge logs --tail
-command! ForgeRegister :!forge register
 
-nnoremap <leader>fd :ForgeDeploy<CR>
-nnoremap <leader>ft :ForgeTunnel<CR>
-nnoremap <leader>fb :ForgeBuildStatic<CR>
-nnoremap <leader>fi :ForgeInstall<CR>
+if executable('forge')
+  command! ForgeCreate :!forge create
+  command! ForgeDeploy :!forge deploy
+  command! ForgeInstall :!forge install
+  command! ForgeTunnel :!forge tunnel
+  command! ForgeBuildStatic :!cd static/hello-world && npm install && npm run build
+  command! ForgeBuildReact :!cd src/frontend && npm install && npm run build
+  command! ForgeLogs :!forge logs --tail
+  command! ForgeRegister :!forge register
+
+  nnoremap <leader>fd :ForgeDeploy<CR>
+  nnoremap <leader>ft :ForgeTunnel<CR>
+  nnoremap <leader>fb :ForgeBuildStatic<CR>
+  nnoremap <leader>fi :ForgeInstall<CR>
+
+  command! ForgeLogin :!forge login
+  command! ForgeLogout :!forge logout
+  command! ForgeWhoAmI :!forge whoami
+  command! ForgeUpgrade :!npm install -g @forge/cli@latest
+  command! ForgeLint :!forge lint
+  " Secret Storage Commands
+  command! -nargs=+ ForgeSetSecret :call system('forge tunnel & sleep 2 && node -e "require('@forge/api').storage.setSecret(\"'.<args>.'\")"')
+  command! -nargs=1 ForgeGetSecret :echo system('node -e "require('@forge/api').storage.getSecret(\"'.<args>.'\").then(console.log)"')
+  command! -nargs=1 ForgeDeleteSecret :call system('node -e "require('@forge/api').storage.deleteSecret(\"'.<args>.'\")"')
+else
+  echo "vim-forge: Forge CLI not found. Please install @forge/cli."
+endif
 
 au BufRead,BufNewFile manifest.yml set filetype=yaml
-command! ForgeLogin :!forge login
-command! ForgeLogout :!forge logout
-command! ForgeWhoAmI :!forge whoami
-command! ForgeUpgrade :!npm install -g @forge/cli@latest
-command! ForgeLint :!forge lint
-" Secret Storage Commands
-command! -nargs=+ ForgeSetSecret :call system('forge tunnel & sleep 2 && node -e "require('@forge/api').storage.setSecret(\"'.<args>.'\")"')
-command! -nargs=1 ForgeGetSecret :echo system('node -e "require('@forge/api').storage.getSecret(\"'.<args>.'\").then(console.log)"')
-command! -nargs=1 ForgeDeleteSecret :call system('node -e "require('@forge/api').storage.deleteSecret(\"'.<args>.'\")"')
 
-" Macro Config Dev Command Stub (placeholder for scaffolding helpers)
-command! ForgeMacroConfigHelp :echo "Use Label + Form components in UI Kit for macro config. See :help vim-forge"
+" Macro Config Dev Command Stub (placeholder for scaffolding helpers)command! ForgeMacroConfigHelp :echo "Use Label + Form components in UI Kit for macro config. See :help vim-forge"

--- a/plugin/vim-rovodev.vim
+++ b/plugin/vim-rovodev.vim
@@ -5,12 +5,16 @@ if exists('g:loaded_rovodev_plugin')
 endif
 let g:loaded_rovodev_plugin = 1
 
-command! RovoDeploy :!acli rovodev deploy
-command! RovoTunnel :!acli rovodev tunnel
-command! RovoInstall :!acli rovodev install
-command! RovoLogs :!acli rovodev logs
+if executable('acli')
+  command! RovoDeploy :!acli rovodev deploy
+  command! RovoTunnel :!acli rovodev tunnel
+  command! RovoInstall :!acli rovodev install
+  command! RovoLogs :!acli rovodev logs
 
-nnoremap <leader>rd :RovoDeploy<CR>
-nnoremap <leader>rt :RovoTunnel<CR>
-nnoremap <leader>ri :RovoInstall<CR>
-nnoremap <leader>rl :RovoLogs<CR>
+  nnoremap <leader>rd :RovoDeploy<CR>
+  nnoremap <leader>rt :RovoTunnel<CR>
+  nnoremap <leader>ri :RovoInstall<CR>
+  nnoremap <leader>rl :RovoLogs<CR>
+else
+  echo "vim-rovodev: acli not found. Please install Atlassian CLI."
+endif


### PR DESCRIPTION
## Summary
- ensure plugin commands only load when the needed CLI exists
- warn users when the Forge CLI or acli is missing

## Testing
- `bash -n scripts/forge-dev.sh`
- `bash -n scripts/rovodev-dev.sh`


------
https://chatgpt.com/codex/tasks/task_e_686d76d9ed3883278e452515e75b83ad